### PR TITLE
Adversarial base model training forcing learned features to forget alt count

### DIFF
--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -481,7 +481,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
     alt_count_loss_func = torch.nn.L1Loss(reduction='none')
     alt_count_adversarial_metrics = LossMetrics(base_model._device)
 
-    train_optimizer = torch.optim.AdamW(chain(base_model.parameters(), learning_strategy.parameters()),
+    train_optimizer = torch.optim.AdamW(chain(base_model.parameters(), learning_strategy.parameters(), alt_count_gradient_reversal.parameters(), alt_count_predictor.parameters()),
                                         lr=training_params.learning_rate, weight_decay=training_params.weight_decay)
     # train scheduler needs to be given the thing that's supposed to decrease at the end of each epoch
     train_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -535,6 +535,18 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
                 classification_loss = torch.sum(batch.is_labeled_mask * weights * classification_losses)
                 classifier_metrics.record_losses(classification_losses.detach(), batch, batch.is_labeled_mask * weights)
 
+                # STUPID DEBUG STUFF
+                if n < 10:
+                    print(f"actual alt counts {batch.alt_counts.tolist()}")
+                    print(f"alt count predictions: {alt_count_pred.detach().tolist()}")
+                    print(f"alt count losses {alt_count_losses.detach().tolist()}")
+                    print(f"weights {weights.tolist()}")
+                    print(f"semisupervised losses {losses.detach().tolist()}")
+                    print(f"classification logits {classification_logits.detach().tolist()}")
+                    print(f"classification losses {classification_losses.detach().tolist()}")
+
+                # DONE DEBUG
+
                 if epoch_type == utils.Epoch.TRAIN:
                     utils.backpropagate(train_optimizer, loss)
                     utils.backpropagate(classifier_optimizer, classification_loss)

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -13,6 +13,7 @@ from tqdm.autonotebook import trange, tqdm
 from permutect import utils, constants
 from permutect.architecture.dna_sequence_convolution import DNASequenceConvolution
 from permutect.architecture.gated_mlp import GatedMLP, GatedRefAltMLP
+from permutect.architecture.gradient_reversal.module import GradientReversal
 from permutect.architecture.mlp import MLP
 from permutect.data.base_datum import BaseBatch, DEFAULT_GPU_FLOAT, DEFAULT_CPU_FLOAT
 from permutect.data.base_dataset import BaseDataset, ALL_COUNTS_SENTINEL
@@ -474,6 +475,12 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
         raise Exception("not implemented yet")
     learning_strategy.to(device=base_model._device, dtype=base_model._dtype)
 
+    # adversarial loss to learn features that forget the alt count
+    alt_count_gradient_reversal = GradientReversal(alpha=0.01)  #initialize as barely active
+    alt_count_predictor = MLP([base_model.output_dimension()] + [30, -1, -1, -1, 1]).to(device=base_model._device, dtype=base_model._dtype)
+    alt_count_mse = torch.nn.MSELoss(reduction='none')
+    alt_count_adversarial_metrics = LossMetrics(base_model._device)
+
     train_optimizer = torch.optim.AdamW(chain(base_model.parameters(), learning_strategy.parameters()),
                                         lr=training_params.learning_rate, weight_decay=training_params.weight_decay)
     # train scheduler needs to be given the thing that's supposed to decrease at the end of each epoch
@@ -491,6 +498,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
     valid_loader = dataset.make_data_loader([validation_fold_to_use], training_params.batch_size, base_model._device.type == 'cuda', training_params.num_workers)
 
     for epoch in trange(1, training_params.num_epochs + 1, desc="Epoch"):
+        alt_count_gradient_reversal.set_alpha((epoch / training_params.num_epochs)) # alpha increases linearly
         print(f"Start of epoch {epoch}, memory usage percent: {psutil.virtual_memory().percent:.1f}")
         for epoch_type in (utils.Epoch.TRAIN, utils.Epoch.VALID):
             base_model.set_epoch_type(epoch_type)
@@ -507,12 +515,20 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
                 if losses is None:
                     continue
 
-                # TODO: maybe this should be done by count?
                 # TODO: we need a parameter to control the relative weight of unlabeled loss to labeled loss
                 weights = calculate_batch_weights(batch, dataset, by_count=True)
 
                 loss_metrics.record_losses(losses.detach(), batch, weights)
-                loss = torch.sum(weights * losses)
+
+                # gradient reversal means parameters before the representation try to maximize alt count prediction loss, i.e. features
+                # try to forget alt count, while parameters after the representation try to minimize it, i.e. they try
+                # to achieve the adversarial task
+                alt_count_pred = alt_count_predictor.forward(alt_count_gradient_reversal(representations)).squeeze()
+                alt_count_losses = alt_count_mse(alt_count_pred, batch.alt_counts)
+
+                alt_count_adversarial_metrics.record_losses(alt_count_losses.detach(), batch, weights=torch.ones_like(alt_count_losses))
+
+                loss = torch.sum((weights * losses) + alt_count_losses)
 
                 classification_logits = classifier_on_top.forward(representations.detach()).reshape(batch.size())
                 classification_losses = classifier_bce(classification_logits, batch.labels)
@@ -526,6 +542,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
             # done with one epoch type -- training or validation -- for this epoch
             loss_metrics.write_to_summary_writer(epoch_type, epoch, summary_writer)
             classifier_metrics.write_to_summary_writer(epoch_type, epoch, summary_writer, prefix="auxiliary-classifier-")
+            alt_count_adversarial_metrics.write_to_summary_writer(epoch_type, epoch, summary_writer, prefix="alt-count-adversarial-predictor")
 
             if epoch_type == utils.Epoch.TRAIN:
                 train_scheduler.step(loss_metrics.get_labeled_loss())

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -524,7 +524,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
                 # try to forget alt count, while parameters after the representation try to minimize it, i.e. they try
                 # to achieve the adversarial task
                 alt_count_pred = alt_count_predictor.forward(alt_count_gradient_reversal(representations)).squeeze()
-                alt_count_losses = alt_count_mse(alt_count_pred, batch.alt_counts)
+                alt_count_losses = alt_count_mse(alt_count_pred, batch.alt_counts.float())
 
                 alt_count_adversarial_metrics.record_losses(alt_count_losses.detach(), batch, weights=torch.ones_like(alt_count_losses))
 

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -478,7 +478,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
     # adversarial loss to learn features that forget the alt count
     alt_count_gradient_reversal = GradientReversal(alpha=0.01)  #initialize as barely active
     alt_count_predictor = MLP([base_model.output_dimension()] + [30, -1, -1, -1, 1]).to(device=base_model._device, dtype=base_model._dtype)
-    alt_count_mse = torch.nn.MSELoss(reduction='none')
+    alt_count_loss_func = torch.nn.L1Loss(reduction='none')
     alt_count_adversarial_metrics = LossMetrics(base_model._device)
 
     train_optimizer = torch.optim.AdamW(chain(base_model.parameters(), learning_strategy.parameters()),
@@ -524,7 +524,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
                 # try to forget alt count, while parameters after the representation try to minimize it, i.e. they try
                 # to achieve the adversarial task
                 alt_count_pred = alt_count_predictor.forward(alt_count_gradient_reversal(representations)).squeeze()
-                alt_count_losses = alt_count_mse(alt_count_pred, batch.alt_counts.float())
+                alt_count_losses = alt_count_loss_func(alt_count_pred, batch.alt_counts.float())
 
                 alt_count_adversarial_metrics.record_losses(alt_count_losses.detach(), batch, weights=torch.ones_like(alt_count_losses))
 

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -549,6 +549,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
 
             print(f"Labeled base model loss for {epoch_type.name} epoch {epoch}: {loss_metrics.get_labeled_loss():.3f}")
             print(f"Labeled auxiliary classifier loss for {epoch_type.name} epoch {epoch}: {classifier_metrics.get_labeled_loss():.3f}")
+            print(f"Alt count adversarial loss for {epoch_type.name} epoch {epoch}: {alt_count_adversarial_metrics.get_labeled_loss():.3f}")
         print(f"End of epoch {epoch}, memory usage percent: {psutil.virtual_memory().percent:.1f}")
         # done with training and validation for this epoch
         # note that we have not learned the AF spectrum yet

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -479,7 +479,7 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
     # adversarial loss to learn features that forget the alt count
     alt_count_gradient_reversal = GradientReversal(alpha=0.01)  #initialize as barely active
     alt_count_predictor = MLP([base_model.output_dimension()] + [30, -1, -1, -1, 1]).to(device=base_model._device, dtype=base_model._dtype)
-    alt_count_loss_func = torch.nn.L1Loss(reduction='none')
+    alt_count_loss_func = torch.nn.MSELoss(reduction='none')
     alt_count_adversarial_metrics = LossMetrics(base_model._device)
 
     train_optimizer = torch.optim.AdamW(chain(base_model.parameters(), learning_strategy.parameters(), alt_count_predictor.parameters()),

--- a/permutect/architecture/gradient_reversal/module.py
+++ b/permutect/architecture/gradient_reversal/module.py
@@ -10,3 +10,6 @@ class GradientReversal(nn.Module):
 
     def forward(self, x):
         return revgrad(x, self.alpha)
+
+    def set_alpha(self, alpha_new):
+        self.alpha = torch.tensor(alpha_new, requires_grad=False)

--- a/permutect/metrics/evaluation_metrics.py
+++ b/permutect/metrics/evaluation_metrics.py
@@ -386,7 +386,7 @@ class EmbeddingMetrics:
             idx = np.random.choice(len(all_metadata), size=min(NUM_DATA_FOR_TENSORBOARD_PROJECTION, len(all_metadata)), replace=False)
 
         summary_writer.add_embedding(torch.vstack(self.representations)[idx],
-                                     metadata=[all_metadata[n] for n in idx],
+                                     metadata=[all_metadata[round(n)] for n in idx.tolist()],
                                      metadata_header=["Labels", "Correctness", "Types", "Counts"],
                                      tag=prefix+"embedding", global_step=epoch)
 
@@ -396,7 +396,7 @@ class EmbeddingMetrics:
             indices = [n for n, type_name in enumerate(self.type_metadata) if type_name == variant_name]
             indices = sample_indices_for_tensorboard(indices)
             summary_writer.add_embedding(torch.vstack(self.representations)[indices],
-                                         metadata=[all_metadata[n] for n in indices],
+                                         metadata=[all_metadata[round(n)] for n in indices.tolist()],
                                          metadata_header=["Labels", "Correctness", "Types", "Counts"],
                                          tag=prefix+"embedding for variant type " + variant_name, global_step=epoch)
 
@@ -407,7 +407,7 @@ class EmbeddingMetrics:
             indices = sample_indices_for_tensorboard(indices)
             if len(indices) > 0:
                 summary_writer.add_embedding(torch.vstack(self.representations)[indices],
-                                        metadata=[all_metadata[n] for n in indices],
+                                        metadata=[all_metadata[round(n)] for n in indices.tolist()],
                                         metadata_header=["Labels", "Correctness", "Types", "Counts"],
                                         tag=prefix+"embedding for alt count " + str(count), global_step=epoch)
 


### PR DESCRIPTION
(The mean field architecture already strongly encourages this, but this wipes away more traces of alt count memory without a noticeable affect on artifact classification loss)

Implementation is a gradient reversal layer below an MLP + sigmoid trying to predict alt count.  The gradient reversal layer means the MLP tries to predict alt count while the base model below it tries to learn features that make alt count prediction impossible.