### PR TITLE
Mixed count base batches

### DIFF
--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -190,9 +190,7 @@ class BaseModel(torch.nn.Module):
         alt_wt_sums_v = utils.sums_over_rows(alt_weights_r, alt_counts)
         normalized_alt_weights_r = alt_weights_r / torch.repeat_interleave(alt_wt_sums_v, repeats=alt_counts, dim=0)
 
-        normalized_alt_weights_vr1 = (alt_weights_vr / alt_wt_sums).reshape(batch.size(), alt_count, 1)
-
-        alt_means_ve = torch.sum(transformed_alt_vre * normalized_alt_weights_vr1, dim=1)
+        alt_means_ve = utils.sums_over_rows(transformed_alt_re * normalized_alt_weights_r[:,None], alt_counts)
 
         result_ve = self.aggregation.forward(alt_means_ve)
 

--- a/permutect/architecture/base_model.py
+++ b/permutect/architecture/base_model.py
@@ -507,11 +507,10 @@ def learn_base_model(base_model: BaseModel, dataset: BaseDataset, learning_metho
         .to(device=base_model._device, dtype=base_model._dtype)
     classifier_bce = torch.nn.BCEWithLogitsLoss(reduction='none')
 
-    # TODO: fused = is_cuda?
     classifier_optimizer = torch.optim.AdamW(classifier_on_top.parameters(),
                                              lr=training_params.learning_rate,
                                              weight_decay=training_params.weight_decay,
-                                             fused=True)
+                                             fused=is_cuda)
     classifier_metrics = LossMetrics()
 
     validation_fold_to_use = (dataset.num_folds - 1) if validation_fold is None else validation_fold

--- a/permutect/data/base_datum.py
+++ b/permutect/data/base_datum.py
@@ -550,7 +550,8 @@ class BaseBatch:
         self._original_list = data
         self.ref_count = len(data[0].reads_2d) - data[0].alt_count
         self.alt_count = data[0].alt_count
-        self.alt_counts = IntTensor([data[0].alt_count for _ in data])
+        self.alt_counts = IntTensor([datum.alt_count for datum in data])
+        self.ref_counts = IntTensor([len(datum.reads_2d) - datum.alt_count for datum in data])
 
         # for datum in data:
         #    assert (datum.label() != Label.UNLABELED) == self.labeled, "Batch may not mix labeled and unlabeled"
@@ -582,6 +583,8 @@ class BaseBatch:
     def pin_memory(self):
         self.ref_sequences_2d = self.ref_sequences_2d.pin_memory()
         self.reads_2d = self.reads_2d.pin_memory()
+        self.alt_counts = self.alt_counts.pin_memory()
+        self.ref_counts = self.ref_counts.pin_memory()
         self.info_2d = self.info_2d.pin_memory()
         self.labels = self.labels.pin_memory()
         self.is_labeled_mask = self.is_labeled_mask.pin_memory()
@@ -598,6 +601,7 @@ class BaseBatch:
         new_batch.is_labeled_mask = self.is_labeled_mask.to(device, non_blocking=non_blocking)
         new_batch.sources = self.sources.to(device, non_blocking=non_blocking)
         new_batch.alt_counts = self.alt_counts.to(device, non_blocking=non_blocking)
+        new_batch.ref_counts = self.ref_counts.to(device, non_blocking=non_blocking)
         return new_batch
 
     def original_list(self):

--- a/permutect/parameters.py
+++ b/permutect/parameters.py
@@ -14,7 +14,7 @@ class BaseModelParameters:
     """
     def __init__(self, read_layers: List[int], num_transformer_heads: int, transformer_hidden_dimension: int,
                  num_transformer_layers: int, info_layers: List[int], aggregation_layers: List[int],
-                 ref_seq_layers_strings: List[str], dropout_p: float, reweighting_range: float, batch_normalize: bool = False, alt_downsample: int = 100):
+                 ref_seq_layers_strings: List[str], dropout_p: float, reweighting_range: float, batch_normalize: bool = False):
 
         self.read_layers = read_layers
         self.info_layers = info_layers
@@ -26,7 +26,6 @@ class BaseModelParameters:
         self.dropout_p = dropout_p
         self.reweighting_range = reweighting_range
         self.batch_normalize = batch_normalize
-        self.alt_downsample = alt_downsample
 
     def output_dimension(self):
         return self.aggregation_layers[-1]
@@ -43,10 +42,9 @@ def parse_base_model_params(args) -> BaseModelParameters:
     dropout_p = getattr(args, constants.DROPOUT_P_NAME)
     reweighting_range = getattr(args, constants.REWEIGHTING_RANGE_NAME)
     batch_normalize = getattr(args, constants.BATCH_NORMALIZE_NAME)
-    alt_downsample = getattr(args, constants.ALT_DOWNSAMPLE_NAME)
     return BaseModelParameters(read_layers, num_transformer_heads, transformer_hidden_dimension,
                                num_transformer_layers, info_layers, aggregation_layers, ref_seq_layer_strings, dropout_p,
-                               reweighting_range, batch_normalize, alt_downsample)
+                               reweighting_range, batch_normalize)
 
 
 def add_base_model_params_to_parser(parser):
@@ -75,8 +73,6 @@ def add_base_model_params_to_parser(parser):
     parser.add_argument('--' + constants.REWEIGHTING_RANGE_NAME, type=float, default=0.3, required=False,
                         help='magnitude of data augmentation by randomly weighted average of read embeddings.  '
                              'a value of x yields random weights between 1 - x and 1 + x')
-    parser.add_argument('--' + constants.ALT_DOWNSAMPLE_NAME, type=int, default=100, required=False,
-                        help='max number of alt reads to downsample to inside the model')
     parser.add_argument('--' + constants.BATCH_NORMALIZE_NAME, action='store_true',
                         help='flag to turn on batch normalization')
 

--- a/permutect/test/tools/test_train_base_model.py
+++ b/permutect/test/tools/test_train_base_model.py
@@ -38,6 +38,7 @@ def test_train_base_model():
     # training hyperparameters
     setattr(train_model_args, constants.REWEIGHTING_RANGE_NAME, 0.3)
     setattr(train_model_args, constants.BATCH_SIZE_NAME, 64)
+    setattr(train_model_args, constants.INFERENCE_BATCH_SIZE_NAME, 64)
     setattr(train_model_args, constants.NUM_WORKERS_NAME, 2)
     setattr(train_model_args, constants.NUM_EPOCHS_NAME, 2)
     setattr(train_model_args, constants.NUM_CALIBRATION_EPOCHS_NAME, 0)

--- a/permutect/test/tools/test_train_base_model.py
+++ b/permutect/test/tools/test_train_base_model.py
@@ -39,7 +39,7 @@ def test_train_base_model():
     setattr(train_model_args, constants.REWEIGHTING_RANGE_NAME, 0.3)
     setattr(train_model_args, constants.BATCH_SIZE_NAME, 64)
     setattr(train_model_args, constants.INFERENCE_BATCH_SIZE_NAME, 64)
-    setattr(train_model_args, constants.NUM_WORKERS_NAME, 2)
+    setattr(train_model_args, constants.NUM_WORKERS_NAME, 0)
     setattr(train_model_args, constants.NUM_EPOCHS_NAME, 2)
     setattr(train_model_args, constants.NUM_CALIBRATION_EPOCHS_NAME, 0)
     setattr(train_model_args, constants.LEARNING_RATE_NAME, 0.001)

--- a/permutect/test/tools/test_train_base_model.py
+++ b/permutect/test/tools/test_train_base_model.py
@@ -27,7 +27,6 @@ def test_train_base_model():
                      'linear/out_features=10']
     setattr(train_model_args, constants.REF_SEQ_LAYER_STRINGS_NAME, cnn_layer_strings)
     setattr(train_model_args, constants.DROPOUT_P_NAME, 0.0)
-    setattr(train_model_args, constants.ALT_DOWNSAMPLE_NAME, 20)
     setattr(train_model_args, constants.BATCH_NORMALIZE_NAME, False)
 
     setattr(train_model_args, constants.LEARNING_METHOD_NAME, 'SEMISUPERVISED')

--- a/permutect/test/tools/test_train_model.py
+++ b/permutect/test/tools/test_train_model.py
@@ -32,6 +32,7 @@ def test_train_model():
 
     # training hyperparameters
     setattr(train_model_args, constants.BATCH_SIZE_NAME, 64)
+    setattr(train_model_args, constants.INFERENCE_BATCH_SIZE_NAME, 64)
     setattr(train_model_args, constants.NUM_WORKERS_NAME, 2)
     setattr(train_model_args, constants.NUM_EPOCHS_NAME, 2)
     setattr(train_model_args, constants.NUM_CALIBRATION_EPOCHS_NAME, 1)

--- a/permutect/test/tools/test_train_model.py
+++ b/permutect/test/tools/test_train_model.py
@@ -33,7 +33,7 @@ def test_train_model():
     # training hyperparameters
     setattr(train_model_args, constants.BATCH_SIZE_NAME, 64)
     setattr(train_model_args, constants.INFERENCE_BATCH_SIZE_NAME, 64)
-    setattr(train_model_args, constants.NUM_WORKERS_NAME, 2)
+    setattr(train_model_args, constants.NUM_WORKERS_NAME, 0)
     setattr(train_model_args, constants.NUM_EPOCHS_NAME, 2)
     setattr(train_model_args, constants.NUM_CALIBRATION_EPOCHS_NAME, 1)
     setattr(train_model_args, constants.LEARNING_RATE_NAME, 0.001)

--- a/permutect/utils.py
+++ b/permutect/utils.py
@@ -183,6 +183,33 @@ def gamma_binomial(n, k, alpha, beta):
     return exponent_term + gamma_term - torch.log(n + 1)
 
 
+# for tensor of shape (R, C...) and row counts n1, n2. . nK, return a tensor of shape (K, C...) whose 1st row is the sum of the
+# first n1 rows of the input, 2nd row is the sum of the next n2 rows etc
+# note that this works for arbitrary C, including empty.  That is, it works for 1D, 2D, 3D etc input.
+def sums_over_rows(input_tensor: torch.Tensor, counts: torch.IntTensor):
+    range_ends = torch.cumsum(counts, dim=0)
+    assert range_ends[-1] == len(input_tensor)   # the counts need to add up!
+
+    row_cumsums = torch.cumsum(input_tensor, dim=0)
+
+    # if counts are eg 1, 2, 3 then range ends are 1, 3, 6 and we are interested in cumsums[0, 2, 5]
+    relevant_cumsums = row_cumsums[(range_ends - 1).long()]
+
+    # if counts are eg 1, 2, 3 we now have, the sum of the first 1, 3, and 6 rows.  To get the sums of row 0, rows 1-2, rows 3-5
+    # we need the consecutive differences, with a row of zeroes prepended
+    row_of_zeroes = torch.zeros_like(relevant_cumsums[0])[None] # the [None] makes it (1xC)
+    relevant_sums = torch.diff(relevant_cumsums, dim=0, prepend=row_of_zeroes)
+    return relevant_sums
+
+
+# same but divide by the counts to get means
+def means_over_rows(input_tensor: torch.Tensor, counts: torch.IntTensor, keepdim: bool = False):
+    extra_dims = (1,) * (input_tensor.dim() - 1)
+    result = sums_over_rows(input_tensor, counts) / counts.view(-1, *extra_dims)
+
+    return torch.repeat_interleave(result, dim=0, repeats=counts) if keepdim else result
+
+
 class StreamingAverage:
     def __init__(self):
         self._count = 0.0

--- a/permutect/utils.py
+++ b/permutect/utils.py
@@ -210,6 +210,19 @@ def means_over_rows(input_tensor: torch.Tensor, counts: torch.IntTensor, keepdim
     return torch.repeat_interleave(result, dim=0, repeats=counts) if keepdim else result
 
 
+# same but include a regularizer in case of zeros in the counts vector
+# regularizer has the dimension of one row of the input tensor
+def means_over_rows_with_regularizer(input_tensor: torch.Tensor, counts: torch.IntTensor, regularizer, regularizer_weight, keepdim: bool = False):
+    # TODO: left off right here
+    extra_dims = (1,) * (input_tensor.dim() - 1)
+
+    regularized_sums = sums_over_rows(input_tensor, counts) + regularizer[None, :]
+    regularized_counts = counts + regularizer_weight
+    result = regularized_sums / regularized_counts.view(-1, *extra_dims)
+
+    return torch.repeat_interleave(result, dim=0, repeats=counts) if keepdim else result
+
+
 class StreamingAverage:
     def __init__(self):
         self._count = 0.0


### PR DESCRIPTION
This changes the gated MLPs in the base model to be able to handle batches with disparate alt and ref counts.  Since batches are now all random samples of data we can probably get away with larger batch sizes, increasing GPU use.

It will also enable greater variety of ref counts.  Previously we have downsampled ref counts to exactly 5 or 10 reads; this is no longer necessary.  That's most likely good for generalizability.