### PR TITLE
slow computing of ref and alt haplotypes is done in datum constructor, not batch

### DIFF
--- a/permutect/data/batch.py
+++ b/permutect/data/batch.py
@@ -13,7 +13,9 @@ class Batch:
         self.data = torch.from_numpy(np.vstack([d.get_array_1d() for d in data])).to(dtype=torch.long)
         self._size = len(data)
 
-        self.info_start = Datum.REF_SEQ_START_IDX + data[0].array[Datum.REF_SEQ_LENGTH_IDX]
+        self.haplotypes_start = Datum.HAPLOTYPES_START_IDX
+        self.haplotypes_end = Datum.HAPLOTYPES_START_IDX + data[0].array[Datum.HAPLOTYPES_LENGTH_IDX]
+        self.info_start = self.haplotypes_end
         info_length = data[0].array[Datum.INFO_LENGTH_IDX]
         self.info_end = self.info_start + info_length
 
@@ -47,17 +49,21 @@ class Batch:
     def get_original_alt_counts(self) -> IntTensor:
         return self.data[:, Datum.ORIGINAL_ALT_COUNT_IDX]
 
-    def get_original_depths(self) -> torch.IntTensor:
+    def get_original_depths(self) -> IntTensor:
         return self.data[:, Datum.ORIGINAL_DEPTH_IDX]
 
-    def get_original_normal_alt_counts(self) -> torch.Tensor:
+    def get_original_normal_alt_counts(self) -> IntTensor:
         return self.data[:, Datum.ORIGINAL_NORMAL_ALT_COUNT_IDX]
 
-    def get_original_normal_depths(self) -> torch.Tensor:
+    def get_original_normal_depths(self) -> IntTensor:
         return self.data[:, Datum.ORIGINAL_NORMAL_DEPTH_IDX]
 
     def get_info_2d(self) -> torch.Tensor:
         return self.data[:, self.info_start:self.info_end] / Datum.FLOAT_TO_LONG_MULTIPLIER
+
+    def get_haplotypes_2d(self) -> IntTensor:
+        # each row is 1D array of integer array reference and alt haplotypes concatenated -- A, C, G, T, deletion = 0, 1, 2, 3, 4
+        return self.data[:, self.haplotypes_start:self.haplotypes_end]
 
     # pin memory for all tensors that are sent to the GPU
     def pin_memory(self):

--- a/permutect/data/features_datum.py
+++ b/permutect/data/features_datum.py
@@ -11,7 +11,7 @@ class FeaturesDatum(Datum):
     """
     """
     def __init__(self, datum_array: np.ndarray, representation: Tensor):
-        super().__init__(datum_array)
+        super().__init__(Datum.copy_data_without_haplotypes_and_info(datum_array))
         # Note: if changing any of the data fields below, make sure to modify the size_in_bytes() method below accordingly!
         assert representation.dim() == 1
         self.representation = torch.clamp(representation, MIN_FLOAT_16, MAX_FLOAT_16)

--- a/permutect/data/reads_dataset.py
+++ b/permutect/data/reads_dataset.py
@@ -136,7 +136,7 @@ class ReadsDataset(Dataset):
         self.source_balancing_weights_sct = torch.from_numpy(self.source_balancing_weights_sct)
         self.num_read_features = self[0].get_reads_2d().shape[1]
         self.num_info_features = len(self[0].get_info_1d())
-        self.ref_sequence_length = len(self[0].get_ref_seq_1d())
+        self.haplotypes_length = len(self[0].get_haplotypes_1d())
 
     def __len__(self):
         return len(self._data) // TENSORS_PER_BASE_DATUM if self._memory_map_mode else len(self._data)

--- a/permutect/test/data/test_reads_batch.py
+++ b/permutect/test/data/test_reads_batch.py
@@ -32,7 +32,7 @@ def test_reads_batch():
 
     batch = permutect.data.reads_batch.ReadsBatch(data)
 
-    assert torch.equal(batch.get_ref_sequences_2d(),
+    assert torch.equal(batch.get_one_hot_haplotypes_2d(),
                        torch.Tensor([
                            [[1,0,0],[0,1,1],[0,0,0],[0,0,0]],
                            [[0,0,0],[0,0,0],[1,0,1],[0,1,0]],

--- a/permutect/test/data/test_reads_datum.py
+++ b/permutect/test/data/test_reads_datum.py
@@ -20,7 +20,6 @@ def test_reads_datum():
 
     snv_datum = ReadsDatum.from_gatk("AC", Variation.SNV, ref_tensor, alt_tensor, gatk_info_tensor, label, source)
 
-    assert torch.equal(snv_datum.get_ref_seq_1d(), torch.Tensor([0,1]))
     assert torch.equal(snv_datum.reads_2d, np.vstack([ref_tensor, alt_tensor]))
     assert permutect.utils.allele_utils.get_variant_type() == Variation.SNV
     assert snv_datum.label == label

--- a/permutect/tools/preprocess_dataset.py
+++ b/permutect/tools/preprocess_dataset.py
@@ -30,14 +30,14 @@ def parse_arguments():
 
 def do_work(training_datasets, training_output_file, chunk_size, sources: List[int]):
     data_files = []
-    num_read_features, num_info_features, ref_sequence_length = ConsistentValue(), ConsistentValue(), ConsistentValue()
+    num_read_features, num_info_features, haplotypes_length = ConsistentValue(), ConsistentValue(), ConsistentValue()
 
     # save all the lists of read sets to tempfiles. . .
     # TODO: left off here.  Need to give it sources, which will need to be command line argument
     for base_data_list in generate_normalized_data(training_datasets, max_bytes_per_chunk=chunk_size, sources=sources):
         num_read_features.check(base_data_list[0].get_reads_2d().shape[1])
         num_info_features.check(base_data_list[0].get_info_1d().shape[0])
-        ref_sequence_length.check(base_data_list[0].get_ref_seq_1d().shape[0])
+        haplotypes_length.check(base_data_list[0].get_haplotypes_1d().shape[0])
 
         with tempfile.NamedTemporaryFile(delete=False) as train_data_file:
             ReadsDatum.save_list(base_data_list, train_data_file)

--- a/permutect/tools/train_permutect_model.py
+++ b/permutect/tools/train_permutect_model.py
@@ -25,7 +25,7 @@ def main_without_parsing(args):
 
     model = saved_model if (saved_model is not None) else \
             PermutectModel(params=params, num_read_features=dataset.num_read_features, num_info_features=dataset.num_info_features,
-                           ref_sequence_length=dataset.ref_sequence_length, device=gpu_if_available())
+                           haplotypes_length=dataset.haplotypes_length, device=gpu_if_available())
 
     train_permutect_model(model, dataset, training_params, summary_writer=summary_writer)
     summary_writer.close()


### PR DESCRIPTION
Thus it is done in preprocessing, not every single time a new batch is created in training.