### PR TITLE
Call-caching hack in WDL scripts because Terra has been buggy

### DIFF
--- a/scripts/make_training_dataset.wdl
+++ b/scripts/make_training_dataset.wdl
@@ -102,9 +102,9 @@ workflow MakeTrainingDataset {
     output {
         File? bamout = Mutect2.bamout
         File? bamout_index = Mutect2.bamout_index
-        File mutect_stats = Mutect2.mutect_stats
-        File permutect_contigs_table = Mutect2.permutect_contigs_table
-        File permutect_read_groups_table = Mutect2.permutect_read_groups_table
+        File? mutect_stats = Mutect2.mutect_stats
+        File? permutect_contigs_table = Mutect2.permutect_contigs_table
+        File? permutect_read_groups_table = Mutect2.permutect_read_groups_table
         File plain_text_dataset = select_first([cached_plain_text_dataset, Mutect2.permutect_training_dataset])
         File train_tar = Preprocess.train_tar
     }


### PR DESCRIPTION
The two WDLs, the one for generating a training dataset and the one for variant calling, that call Mutect2 as a subworkflow how have optional inputs for cached output of Mutect2.  Terra used to successfully call-cache these files but in the last month it has stopped.

This is a big problem for development because we often change the Permutect docker for experiments but only rarely change the Mutect2 GATK code.  With this hack we can once again run experiments without the expensive and time-consuming Mutect2 steps.